### PR TITLE
更正文字错误

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -1762,7 +1762,7 @@ npm i pnpm -g
 
 所以那就来个简化导航栏，其他同理
 
-在 `.vitepress` 目录新建 `config` 文件夹，并新建 `index.ts` 文件
+在 `.vitepress` 目录新建 `configs` 文件夹，并新建 `index.ts` 文件
 
 ```md{5-6}
 .


### PR DESCRIPTION
感谢大佬超详细的教程！！

在学习教程时发现的小错误，一直报错，才发现是新建了 config 文件夹（而不是 configs ）导致 vitepress 将这个识别成了主配置文件。
（应该是这样吧，小白刚开始学，有错误还请指正）


- 在 `.vitepress` 目录新建 `config` 文件夹

更改为

- 在 `.vitepress` 目录新建 `configs` 文件夹